### PR TITLE
NEXTPY-4204 -- Make pdfquery compatible with Python 3.11 to 3.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: python
 python:
-  - "3.9"
   - "3.11"
+  - "3.12"
+  - "3.13"
+  - "3.14"
 env: CFLAGS="-O0"
 
 cache:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,8 +1,7 @@
-v0.5.0, 2021-05-03 -- 
 0.5.3 (unreleased)
                   
 
-- Nothing changed yet.
+- Make pdfquery compatible with Python 3.11 to 3.14
 
 
 0.5.2 (2025-08-21)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,9 @@
 environment:
   matrix:
-    - PYTHON: "C:\\Python39"
     - PYTHON: "C:\\Python311"
+    - PYTHON: "C:\\Python312"
+    - PYTHON: "C:\\Python313"
+    - PYTHON: "C:\\Python314"
 
 build: off
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ classifiers =
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Topic :: Software Development :: Libraries :: Python Modules
 
 [options]


### PR DESCRIPTION
Local tests
<img width="1727" height="799" alt="image" src="https://github.com/user-attachments/assets/53312034-bd35-4760-9588-342e53d70cc2" />
